### PR TITLE
[ refactor ] Make auto-params be ordered so that likely overriden is 1st

### DIFF
--- a/src/Hedgehog/Internal/Gen.idr
+++ b/src/Hedgehog/Internal/Gen.idr
@@ -574,7 +574,7 @@ printWith si se gen = let (MkCotree v fo) = runGen si se gen
 |||   > 'b'
 |||   > 'c'
 export
-print : (HasIO io, Show a) => Gen a -> io ()
+print : Show a => HasIO io => Gen a -> io ()
 print gen = initSMGen >>= \se => printWith 100 se gen
 
 ||| Generate a sample from a generator.
@@ -602,7 +602,8 @@ renderTree md mw si se = drawTree
 |||
 ||| Use 'printTree' to generate a value from a random seed.
 export
-printTreeWith :  (HasIO io, Show a)
+printTreeWith :  Show a
+              => HasIO io
               => (maxDepth : Nat)
               -> (maxWidth : Nat)
               -> Size
@@ -629,7 +630,8 @@ printTreeWith md mw si se = putStrLn . renderTree md mw si se
 |||   /This may not terminate when the tree is very large./
 |||
 export
-printTree :  (HasIO io, Show a)
+printTree :  Show a
+          => HasIO io
           => (maxDepth : Nat)
           -> (maxWidth : Nat)
           -> Gen a

--- a/src/Hedgehog/Internal/Property.idr
+++ b/src/Hedgehog/Internal/Property.idr
@@ -381,7 +381,7 @@ annotate v = writeLog $ Annotation v
 ||| Annotates the source code with a value that might be useful for
 ||| debugging a test failure.
 export %inline
-annotateShow : (Applicative m, Show a) => a -> TestT m ()
+annotateShow : Show a => Applicative m => a -> TestT m ()
 annotateShow v = annotate $ ppShow v
 
 ||| Logs a message to be displayed as additional information in the footer of
@@ -393,12 +393,12 @@ footnote v = writeLog $ Footnote v
 ||| Logs a value to be displayed as additional information in the footer of
 ||| the failure report.
 export %inline
-footnoteShow : (Applicative m, Show a) => a -> TestT m ()
+footnoteShow : Show a => Applicative m => a -> TestT m ()
 footnoteShow v = writeLog (Footnote $ ppShow v)
 
 ||| Fails with an error that shows the difference between two values.
 export %inline
-failDiff : (Applicative m, Show a, Show b) => a -> b -> TestT m ()
+failDiff : Show a => Show b => Applicative m => a -> b -> TestT m ()
 failDiff x y =
   case valueDiff <$> reify x <*> reify y of
     Nothing =>
@@ -447,7 +447,9 @@ assert ok = if ok then success else failure
 ||| /diff is shown.
 |||
 export %inline
-diff :  (Monad m, Show a, Show b)
+diff :  Show a
+     => Show b
+     => Monad m
      => a -> (a -> b -> Bool) -> b -> TestT m ()
 diff x op y = if x `op` y then success else failDiff x y
 
@@ -455,21 +457,21 @@ infix 4 ===
 
 ||| Fails the test if the two arguments provided are not equal.
 export %inline
-(===) : (Monad m, Eq a, Show a) => a -> a -> TestT m ()
+(===) : Eq a => Show a => Monad m => a -> a -> TestT m ()
 (===) x y = diff x (==) y
 
 infix 4 /==
 
 ||| Fails the test if the two arguments provided are equal.
 export %inline
-(/==) : (Monad m, Eq a, Show a) => a -> a -> TestT m ()
+(/==) : Eq a => Show a => Monad m => a -> a -> TestT m ()
 (/==) x y = diff x (/=) y
 
 
 ||| Fails the test if the 'Either' is 'Left', otherwise returns the value in
 ||| the 'Right'.
 export
-evalEither : (Monad m, Show x) => Either x a -> TestT m a
+evalEither : Show x => Monad m => Either x a -> TestT m a
 evalEither (Left x)  = failWith Nothing (ppShow x)
 evalEither (Right x) = pure x
 
@@ -688,7 +690,7 @@ label name = cover 0 name True
 
 ||| Like 'label', but uses 'Show' to render its argument for display.
 export
-collect : (Monad m, Show a) => a -> TestT m ()
+collect : Show a => Monad m => a -> TestT m ()
 collect x = cover 0 (MkTagged $ show x) True
 
 

--- a/src/Hedgehog/Internal/Range.idr
+++ b/src/Hedgehog/Internal/Range.idr
@@ -179,7 +179,7 @@ constant x y = constantFrom x x y
 ||| >>> origin (constantBounded :: Range Int8)
 ||| 0
 export
-constantBounded : (MinBound a, MaxBound a, Num a) => Range a
+constantBounded : (MinBound a, MaxBound a) => Num a => Range a
 constantBounded = constantFrom 0 minBound maxBound
 
 --------------------------------------------------------------------------------
@@ -210,7 +210,7 @@ scaleLinear sz o0 b0 =
 
 ||| Scales a fractional value linearly with the size parameter.
 export
-scaleLinearFrac :  (Neg a, Fractional a) => Size -> (origin,bound : a) -> a
+scaleLinearFrac : Fractional a => Neg a => Size -> (origin,bound : a) -> a
 scaleLinearFrac sz o b =
   let diff = (b - o) * (fromIntegral sz / 100)
    in o + diff
@@ -252,7 +252,9 @@ linearFin n = map toFin $ linearFrom 0 0 (natToInteger n)
 |||
 ||| This works the same as 'linearFrom', but for fractional values.
 export
-linearFracFrom :  (Neg a, Ord a, Fractional a)
+linearFracFrom :  Ord a
+               => Fractional a
+               => Neg a
                => (origin,lower,uppder : a) -> Range a
 linearFracFrom = scaled scaleLinearFrac
 
@@ -268,7 +270,7 @@ linearFracFrom = scaled scaleLinearFrac
 ||| >>> bounds 99 (linearBounded :: Range Int8)
 |||   (-128,127)
 export
-linearBounded :  (MinBound a, MaxBound a, Ord a, ToInteger a) => Range a
+linearBounded :  (MinBound a, MaxBound a) => Ord a => ToInteger a => Range a
 linearBounded = linearFrom minBound minBound maxBound
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Well, that all began when I needed to use an alternative `Eq` for `===`, and thus it looked like `(x === y) @{(%search, EqImpl, %search)}` instead of `(x === y) @{EqImpl}`, and then I looked through other possibly similar situations which I think one can ran into.