### PR TITLE
[ racket ] use 0xffff_ffff as upper bound in prim__random_Bits64

### DIFF
--- a/src/Hedgehog/Internal/Seed.idr
+++ b/src/Hedgehog/Internal/Seed.idr
@@ -107,7 +107,7 @@ export
 initSMGen : HasIO io => io Seed
 initSMGen = liftIO
           . map smGen
-          $ fromPrim (prim__random_Bits64 maxBound)
+          $ fromPrim (prim__random_Bits64 0xffff_ffff)
 
 ||| Split a generator into a two uncorrelated generators.
 |||


### PR DESCRIPTION
racket throws an error if using a larger upper bound than this when invoking `pseudo-random-generator?`.