### PR TITLE
[ refactor ] Move self-testing facilities to an importable module

### DIFF
--- a/hedgehog.ipkg
+++ b/hedgehog.ipkg
@@ -32,3 +32,4 @@ modules = Data.Bounded
         , Hedgehog.Internal.Shrink
         , Hedgehog.Internal.Terminal
         , Hedgehog.Internal.Util
+        , Hedgehog.Meta

--- a/src/Hedgehog/Meta.idr
+++ b/src/Hedgehog/Meta.idr
@@ -1,4 +1,7 @@
-module Common
+||| Facilities for testing Hedgehog using Hedgehog
+|||
+||| Module contains properties to check how Hedgehog behaves on given properties
+module Hedgehog.Meta
 
 import Control.Monad.Identity
 import Control.Monad.Writer
@@ -33,6 +36,12 @@ doCheck expected checker = do
   annotateSeedIfNeeded actual
   diff actual containsEach (trimDeep $ lines expected)
 
+||| A property checking that Hedgehog being run on a particular property
+||| with particular configuration prints expected string.
+|||
+||| The check passes if every line of Hedgehog's output contains a corresponding
+||| line of `expected` string as a substring. Empty lines, leading and traling
+||| spaces are ignored in both the `expected` string, and Hedgehog's output.
 export
 recheckGivenOutput :
      (expected : String)
@@ -43,6 +52,12 @@ recheckGivenOutput :
 recheckGivenOutput expected prop sz sd = property $
   doCheck expected $ recheck @{DefaultConfig} sz sd prop
 
+||| A property checking that Hedgehog being run on a default configuration
+||| and a random seed prints expected string.
+|||
+||| The check passes if every line of Hedgehog's output contains a corresponding
+||| line of `expected` string as a substring. Empty lines, leading and traling
+||| spaces are ignored in both the `expected` string, and Hedgehog's output.
 export
 checkGivenOutput : (expected : String) -> (prop : Property) -> Property
 checkGivenOutput expected prop = property $ do

--- a/tests/Basic.idr
+++ b/tests/Basic.idr
@@ -1,6 +1,6 @@
 module Basic
 
-import Common
+import Hedgehog.Meta
 
 %default total
 

--- a/tests/Functions/DeriveCogen.idr
+++ b/tests/Functions/DeriveCogen.idr
@@ -1,8 +1,8 @@
 module Functions.DeriveCogen
 
-import Common
-
 import Derive.Cogen
+
+import Hedgehog.Meta
 
 %language ElabReflection
 

--- a/tests/Functions/NoShrink.idr
+++ b/tests/Functions/NoShrink.idr
@@ -1,6 +1,6 @@
 module Functions.NoShrink
 
-import Common
+import Hedgehog.Meta
 
 [FnStub] Show (Nat -> Nat) where
   show _ = "<fn>"

--- a/tests/Functions/Shrink.idr
+++ b/tests/Functions/Shrink.idr
@@ -1,6 +1,6 @@
 module Functions.Shrink
 
-import Common
+import Hedgehog.Meta
 
 export
 simpleFunPrint : Property


### PR DESCRIPTION
I found facilities that I added for self-testing of Hedgehog to be extremely useful for automatic checking the properties I'm showing on a lecture slides (having that I write them using literate Idris and I want them to be checked when slides are built).

So, I propose to move `test/Common.idr` to be a `Hedgehog.Meta` module. I didn't add this to the `Hedgehog` module as reexport, or to `Internals` because this module is not meant to be imported by every user, so if it is needed, user should import it explicitly (and if it was added to `Internals`, it would be bad that user imports something from internals directly).

Also, since this is became a publicly available module, I've added documentation to exported functions.

@stefan-hoeck what do you think?