### PR TITLE
[ fix ] Make early-terminating coverage check be more useful

### DIFF
--- a/src/Hedgehog/Internal/Property.idr
+++ b/src/Hedgehog/Internal/Property.idr
@@ -538,6 +538,7 @@ namespace Property
   mapConfig : (PropertyConfig -> PropertyConfig) -> Property -> Property
   mapConfig f p = { config $= f } p
 
+  export
   verifiedTermination : Property -> Property
   verifiedTermination =
     mapConfig $ \config =>

--- a/src/Hedgehog/Internal/Property.idr
+++ b/src/Hedgehog/Internal/Property.idr
@@ -50,6 +50,10 @@ Semigroup (Tagged t Nat) where (<+>) = (+)
 public export %inline
 Monoid (Tagged t Nat) where neutral = 0
 
+public export %inline
+Show a => Interpolation (Tagged t a) where
+  interpolate (MkTagged x) = show x
+
 ||| The total number of tests which are covered by a classifier.
 |||
 ||| Can be constructed using numeric literals.

--- a/src/Hedgehog/Internal/Report.idr
+++ b/src/Hedgehog/Internal/Report.idr
@@ -565,10 +565,10 @@ report aborted tests size seed cover conf =
            then successReport
            else
              failureReport
-               "Test coverage cannot be reached after \{show tests} tests"
+               "Test coverage cannot be reached after \{tests} tests"
 
   in if aborted then confidenceReport
      else if labelsCovered then successReport
      else
        failureReport $
-         "Labels not sufficently covered after \{show tests} tests"
+         "Labels not sufficently covered after \{tests} tests"


### PR DESCRIPTION
Export obviously forgotten to be exported function that turns on coverage check mode