### PR TITLE
[ upstream ] Refactor code appropriately in reaction to upstream

### DIFF
--- a/src/Hedgehog/Internal/Config.idr
+++ b/src/Hedgehog/Internal/Config.idr
@@ -71,7 +71,9 @@ HasIO io => HasConfig io where
 |||
 ||| This implementation is applicable for any applicative context,
 ||| including pure ones.
-export -- should be a `%defaulthint`, but does not work due to issue #2850
-[DefaultConfig] Applicative m => HasConfig m where
-  detectColor     = pure DisableColor
-  detectVerbosity = pure Normal
+export %defaulthint
+DefaultConfig : Applicative m => HasConfig m
+DefaultConfig = D where
+  [D] HasConfig m where
+    detectColor     = pure DisableColor
+    detectVerbosity = pure Normal

--- a/src/Hedgehog/Internal/Function.idr
+++ b/src/Hedgehog/Internal/Function.idr
@@ -227,7 +227,7 @@ dargdepfun_ bg =
 -- Claessen, K. Shrinking and showing functions:(functional pearl).
 -- In ACM SIGPLAN Notices (Vol. 47, No. 12, pp. 73-80). ACM. 2012, September
 
-infixr 5 :->
+export infixr 5 :->
 
 ||| A type of reified partial functions that can be represented isomorphic
 ||| to a function defined by pattern matching of an ADT

--- a/src/Hedgehog/Internal/Runner.idr
+++ b/src/Hedgehog/Internal/Runner.idr
@@ -158,8 +158,8 @@ checkWith term color name prop =
 ||| Check a property.
 export
 checkNamed :
-     {auto _ : HasConfig m}
-  -> {auto _ : CanInitSeed m}
+     {auto _ : CanInitSeed m}
+  -> {auto _ : HasConfig m}
   -> {auto _ : HasTerminal m}
   -> {auto _ : Monad m}
   -> PropertyName
@@ -174,8 +174,8 @@ checkNamed name prop = do
 ||| Check a property.
 export
 check :
-     {auto _ : HasConfig m}
-  -> {auto _ : CanInitSeed m}
+     {auto _ : CanInitSeed m}
+  -> {auto _ : HasConfig m}
   -> {auto _ : HasTerminal m}
   -> {auto _ : Monad m}
   -> Property
@@ -222,8 +222,8 @@ checkGroupWith term color = run neutral
 
 export
 checkGroup :
-     {auto _ : HasConfig m}
-  -> {auto _ : CanInitSeed m}
+     {auto _ : CanInitSeed m}
+  -> {auto _ : HasConfig m}
   -> {auto _ : HasTerminal m}
   -> {auto _ : Monad m}
   -> Group

--- a/src/Hedgehog/Meta.idr
+++ b/src/Hedgehog/Meta.idr
@@ -50,7 +50,7 @@ recheckGivenOutput :
   -> Seed
   -> Property
 recheckGivenOutput expected prop sz sd = property $
-  doCheck expected $ recheck @{DefaultConfig} sz sd prop
+  doCheck expected $ recheck sz sd prop
 
 ||| A property checking that Hedgehog being run on a default configuration
 ||| and a random seed prints expected string.
@@ -63,4 +63,4 @@ checkGivenOutput : (expected : String) -> (prop : Property) -> Property
 checkGivenOutput expected prop = property $ do
   initSeed <- forAll $ integral_ $ constant 0 MaxRobustSmGenNum
   doCheck expected $
-    ignore $ check @{Manual $ smGen initSeed} @{DefaultConfig} prop
+    ignore $ check @{Manual $ smGen initSeed} prop

--- a/src/Hedgehog/Meta.idr
+++ b/src/Hedgehog/Meta.idr
@@ -63,4 +63,4 @@ checkGivenOutput : (expected : String) -> (prop : Property) -> Property
 checkGivenOutput expected prop = property $ do
   initSeed <- forAll $ integral_ $ constant 0 MaxRobustSmGenNum
   doCheck expected $
-    ignore $ check @{DefaultConfig} @{Manual $ smGen initSeed} prop
+    ignore $ check @{Manual $ smGen initSeed} @{DefaultConfig} prop


### PR DESCRIPTION
Compiler now warns on non-explicitly exported fixities, plus `%defaulthint`'s dependencies resolution is fixed now, allowing us to use `DefaultConfig` from `Meta` as it was originally intended to be used (this is a backwards-compatible change). Plus, the order of auto-implicits of functions in `Meta` was changed slightly to be more regular and easier to use having default config change.