### PR TITLE
[ new ] export checkReport for structured test reports

### DIFF
--- a/src/Hedgehog.idr
+++ b/src/Hedgehog.idr
@@ -7,6 +7,7 @@ import public Hedgehog.Internal.Gen as Hedgehog
 import public Hedgehog.Internal.Function as Hedgehog
 import public Hedgehog.Internal.Property as Hedgehog
 import public Hedgehog.Internal.Range as Hedgehog
+import public Hedgehog.Internal.Report as Hedgehog
 import public Hedgehog.Internal.Runner as Hedgehog
 import public Hedgehog.Internal.Shrink as Hedgehog
 import public Hedgehog.Internal.Terminal as Hedgehog

--- a/src/Hedgehog/Internal/Runner.idr
+++ b/src/Hedgehog/Internal/Runner.idr
@@ -69,7 +69,8 @@ takeSmallest si se (MkTagged slimit) updateUI t = do
 --          Test Runners
 --------------------------------------------------------------------------------
 
--- main test runner
+||| The low-level runner behind `check`, returning the full `Report Result`.
+export
 checkReport :
      {auto _ : Monad m}
   -> PropertyConfig


### PR DESCRIPTION
`checkReport` returns the full `Report Result` but is private, so libraries built on top of hedgehog can only get the `Bool` from `check`/`checkNamed`.
This PR exports it.